### PR TITLE
tzfpy rust 1.82 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: aea7d6e12d8c0c0e41321854867816c779e597b0f0ca0635f20ecd6ab4daebdc
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   skip: true  # [win and python_impl=="pypy"]
   script:


### PR DESCRIPTION
tzfpy rebuild :snowflake:

**Destination channel:** Snowflake 

### Links

- [PKG-6196](https://anaconda.atlassian.net/browse/PKG-6196) 

### Explanation of changes:
  - Bump build number and build with rust 1.82

Rust < 1.81 was affected by CVE-2024-43402.


[PKG-6196]: https://anaconda.atlassian.net/browse/PKG-6196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ